### PR TITLE
Обновление README.md для версии 9.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Gitlab windows1251 issue fix
 
 ## Current FIX
-Version Gitlab **8.14.2**
+Version Gitlab **8.14.2** (**9.0.2**)
 
 #### encoding_helper.rb
 * Source file: [encoding_helper.rb](https://github.com/xRayDev/gitlab_windows1251/blob/323047eca8c8c28a8b5705bcdf7efe1ad444cc89/encoding_helper.rb)
-* Path: /opt/gitlab/embedded/service/gem/ruby/2.3.0/gems/gitlab_git-**10.7.0**/lib/gitlab_git/**encoding_helper.rb**
+* Path 8.14.2: /opt/gitlab/embedded/service/gem/ruby/2.3.0/gems/gitlab_git-**10.7.0**/lib/gitlab_git/**encoding_helper.rb**  
+(Path 9.0.2: /opt/gitlab/embedded/service/gitlab-rails/lib/gitlab/git/**encoding_helper.rb**)
 * **Fix:** https://github.com/xRayDev/gitlab_windows1251/commit/21c7914500e3d1a8f6b68985cedfe9e65f5006d7
 * Link to a source file in the repository Gitlab: [encoding_helper.rb](https://gitlab.com/gitlab-org/gitlab_git/blob/18a00af5f4a5bd5bd932071fa14fb5bafd86a3ab/lib/gitlab_git/encoding_helper.rb)
 
+
+
 #### grit_ext.rb
 * Source file: [grit_ext.rb](https://github.com/xRayDev/gitlab_windows1251/blob/fae5ad9c645b72d1db80c28b89c3e5fea2b7a220/grit_ext.rb)
-* Path: /opt/gitlab/embedded/service/gem/ruby/2.3.0/gems/gitlab-grit-**2.8.1**/lib/**grit_ext.rb**
+* Path  8.14.2: /opt/gitlab/embedded/service/gem/ruby/2.3.0/gems/gitlab-grit-**2.8.1**/lib/**grit_ext.rb**  
+(Path 9.0.2: /opt/gitlab/embedded/lib/ruby/gems/2.3.0/gems/gitlab-grit-**2.8.1**/lib/**grit_ext.rb**)
 * **Fix:** https://github.com/xRayDev/gitlab_windows1251/commit/0340b4fe93186876d78c9ce1e1de8116696280ea
 * Link to a source file in the repository Gitlab: [grit_ext.rb](https://gitlab.com/gitlab-org/gitlab-grit/blob/806485740f9706b913ceaa1fa665880495fc55d1/lib/grit_ext.rb)
 


### PR DESCRIPTION
Пару месяцев назад выложенное Вами решением мне помогло. Но вчера обновил gitlab до 9.0.2, решения проблемы по-прежнему нет. Поэтому, пришлось снова править файлы. Фикс всё-еще работает, но вот файлы находятся уже в других каталогах. Их и добавил, вдруг кому-нибудь будет полезно - не тратить время на поиски.